### PR TITLE
Add a client-path parameter, and make the set token call vm specific

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,11 @@ FROM registry.access.redhat.com/ubi8/go-toolset:latest AS build
 WORKDIR /app
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/ /app/...
+USER 0
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -buildvcs=false -o /app/ /app/...
 
 # deploy stage
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 WORKDIR /app
 RUN mkdir -p /app/web/public

--- a/cmd/kube-gateway/main.go
+++ b/cmd/kube-gateway/main.go
@@ -35,6 +35,7 @@ func main() {
 	publicDir := flag.String("public-dir", "./web/public", "localhost directory containing static web assets.")
 	basePath := flag.String("base-path", "/", "url endpoint for static web assets.")
 	apiPath := flag.String("api-path", "/k8s/", "url endpoint for API calls.")
+	clientPath := flag.String("client-path", "/noVNC/vnc_lite.html", "url endpoint for user client calls.")
 
 	apiServer := flag.String("api-server", "https://kubernetes.default.svc", "backend API server URL.")
 	apiServerSkipVerifyTLS := flag.Bool("api-server-skip-verify-tls", false, "When true, skip verification of certs presented by k8s API server.")
@@ -170,7 +171,7 @@ func main() {
 	http.Handle(s.APIPath, s.AuthMiddleware(s.APIProxy()))
 
 	// Register set token cookie endpoint
-	http.HandleFunc(setTokenEndpoint, token.SetToken)
+	http.HandleFunc(setTokenEndpoint, token.SetTokenFactory(*clientPath, *apiPath))
 
 	// Register static file server
 	fs := http.FileServer(http.Dir(*publicDir))

--- a/deploy/kube-gateway.yaml
+++ b/deploy/kube-gateway.yaml
@@ -38,6 +38,7 @@ spec:
       - command:
         - ./kube-gateway
         - -api-server=$(API_URL)
+        - -client-path=$(CLIENT_URL)
         - -gateway-listen=$(LISTEN)
         - -api-server-ca-file=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
         - -api-server-bearer-token-file=/var/run/secrets/kubernetes.io/serviceaccount/token
@@ -49,6 +50,8 @@ spec:
         env:
         - name: API_URL
           value: https://kubernetes.default.svc
+        - name: CLIENT_URL
+          value: /noVNC/vnc_lite.html
         - name: LISTEN
           value: https://0.0.0.0:8080
         image: quay.io/kubevirt-ui/kube-gateway

--- a/deploy/route.yaml
+++ b/deploy/route.yaml
@@ -7,7 +7,7 @@ metadata:
   name: kube-gateway-route
   namespace: kube-gateway
 spec:
-  host: kube-gateway.apps.ironmaiden1.eng.lab.tlv.redhat.com
+  host: kube-gateway.apps-crc.testing
   port:
     targetPort: 8080
   tls:

--- a/web/public/login
+++ b/web/public/login
@@ -5,12 +5,14 @@
         function load() {
             const urlParams = new URLSearchParams(window.location.search);
             const token = urlParams.get('token');
-            const then = urlParams.get('then');
+            const name = urlParams.get('name');
+            const namespace = urlParams.get('namespace');
 
             document.getElementById("token").value = token
-            document.getElementById("then").value = then
+            document.getElementById("name").value = name
+            document.getElementById("namespace").value = namespace
 
-            if (token && then) {
+            if (token && name && namespace) {
                 document.getElementById("login").submit(); 
             }
         }
@@ -25,9 +27,10 @@
         <form id="login" name="login" action="/auth/jwt/set" method="POST">
             <label for="token">Token</label><br/>
             <textarea name="token" id="token" rows="10" cols="40"></textarea><br/>
-            <label for="then">Then</label><br/>
-            <input id="then" name="then" size="35"/><br/>
-            <p class="help">For example: /noVNC/vnc_lite.html?path=k8s/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/testvm/vnc<p>
+            <label for="name">Virtual machine name</label><br/>
+            <input id="name" name="name" size="35"/><br/>
+            <label for="namespace">Virtual machine namespace</label><br/>
+            <input id="namespace" name="namespace" size="35"/><br/>
             <input type="submit" value="Submit">
         </form>
     </div>


### PR DESCRIPTION
Issue:
Currently a user need to specify the VNC client path and virtual machine full API URL
The VNC path is static and can be specified when starting the proxy
The virtual machine full API URL can be calculated from the vm name and namespace

What this PR do:

Breaking changes:
  - proxy will no longer accept `then` argument
  - proxy will look for vm `name` and `namespace` arguments

Example:

Deprecated:
``` bash
signed_link="${proxyurl}/auth/jwt/set?token=${jwt}&then=/noVNC/vnc_lite.html?path=k8s${path}"
google-chrome "${signed_link}"
```

New format:
``` bash
signed_link="${proxyurl}/auth/jwt/set?token=${jwt}&name=${vmname}&namespace=${vmnamespace}"
google-chrome "${signed_link}"
```

Running the CLI proxy:
```bash
./kube-gateway --help
  ...
  -client-path string
    	url endpoint for user client calls. (default "/noVNC/vnc_lite.html")
  ...
```
``` bash
./kube-gateway -client-path  "/noVNC/vnc_lite.html"

```

Changes:
 - [x] Remove the `then` URL search argument from the proxy server arguments
 - [x] Add virtual machine name and namespace to the URL search argument from the proxy server arguments
 - [x] Add a `-client-path` CLI argument to kube-gateway CLI application
 - [x] Add `-client-path` CLI argument value to the example kuebernetes yaml deployment file
 - [x] Update base container image from ubi8/ubi-minimal to ubi9/ubi-minimal
 - [x] Update readme to use virtual machine name and namespace, instead of API path
